### PR TITLE
Updating the old dependencies and fixing broken links

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,5 +2,5 @@
 bin_dir:      "/usr/local/bin"
 lib_dir:      "/usr/local/lib"
 
-build_dir:    "/home/vagrant/ffmpeg_build"
-source_dir:   "/home/vagrant/ffmpeg_sources"
+build_dir:    "/home/{{ansible_user}}/ffmpeg_build"
+source_dir:   "/home/{{ansible_user}}/ffmpeg_sources"

--- a/tasks/ff-libraries.yml
+++ b/tasks/ff-libraries.yml
@@ -20,3 +20,4 @@
     - nasm
     - pkgconfig
     - zlib-devel
+    - unzip

--- a/tasks/ff-libraries.yml
+++ b/tasks/ff-libraries.yml
@@ -4,6 +4,7 @@
   yum: name=ffmpeg state=absent
 
 - name: Install dependencies
+  become: yes
   yum: name={{ item }} state=present
   with_items:
     - autoconf

--- a/tasks/ff-libraries.yml
+++ b/tasks/ff-libraries.yml
@@ -20,4 +20,3 @@
     - nasm
     - pkgconfig
     - zlib-devel
-    - unzip

--- a/tasks/ff-libraries.yml
+++ b/tasks/ff-libraries.yml
@@ -8,7 +8,7 @@
   become: yes
   template:
     src: nasm.repo
-    dest: /etc/yum/yum.repos.d/nasm.repo
+    dest: /etc/yum.repos.d/nasm.repo
 
 - name: Install dependencies
   become: yes

--- a/tasks/ff-libraries.yml
+++ b/tasks/ff-libraries.yml
@@ -3,6 +3,13 @@
   become: yes
   yum: name=ffmpeg state=absent
 
+# ffmpeg needs >= nasm-2.13
+- name: add nasm repo
+  become: yes
+  template:
+    src: nasm.repo
+    dest: /etc/yum/yum.repos.d/nasm.repo
+
 - name: Install dependencies
   become: yes
   yum: name={{ item }} state=present

--- a/tasks/ff-libraries.yml
+++ b/tasks/ff-libraries.yml
@@ -12,7 +12,7 @@
 
 - name: Install dependencies
   become: yes
-  yum: name={{ item }} state=present
+  yum: name={{ item }} state=latest
   with_items:
     - autoconf
     - automake

--- a/tasks/ffmpeg.yml
+++ b/tasks/ffmpeg.yml
@@ -6,6 +6,7 @@
        depth=1
 
 - name: Compile | ffmpeg
+  become: yes
   shell: "export PATH=/usr/local/bin/:$PATH && {{ item }}"
   args:
     chdir: "{{ source_dir }}/ffmpeg"
@@ -18,4 +19,5 @@
     - hash -r
 
 - name: Symlink | ffmpeg
+  become: yes
   file: state=link src=/usr/local/bin/ffmpeg dest=/usr/bin/ffmpeg

--- a/tasks/ffmpeg.yml
+++ b/tasks/ffmpeg.yml
@@ -12,7 +12,7 @@
     chdir: "{{ source_dir }}/ffmpeg"
     creates: "{{ bin_dir }}/ffmpeg"
   with_items:
-    - PKG_CONFIG_PATH="{{ build_dir }}/lib/pkgconfig" ./configure --prefix={{ build_dir }} --extra-cflags="-I{{ build_dir }}/include" --extra-ldflags="-L{{ build_dir }}/lib" --bindir={{ bin_dir }} --pkg-config-flags="--static" --enable-gpl --enable-nonfree --enable-libfdk-aac --enable-libfreetype --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265
+    - PKG_CONFIG_PATH="{{ build_dir }}/lib/pkgconfig" ./configure --prefix={{ build_dir }} --extra-cflags="-I{{ build_dir }}/include" --extra-ldflags="-L{{ build_dir }}/lib" --bindir={{ bin_dir }} --pkg-config-flags="--static" --enable-gpl --enable-nonfree --enable-libfdk-aac --enable-libfreetype --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --extra-libs=-lpthread
     - make
     - make install
     - make distclean
@@ -21,3 +21,4 @@
 - name: Symlink | ffmpeg
   become: yes
   file: state=link src=/usr/local/bin/ffmpeg dest=/usr/bin/ffmpeg
+  

--- a/tasks/ffmpeg.yml
+++ b/tasks/ffmpeg.yml
@@ -1,6 +1,6 @@
 ---
 - name: GIT clone | ffmpeg
-  git: repo=git://source.ffmpeg.org/ffmpeg.git
+  git: repo=https://git.ffmpeg.org/ffmpeg.git
        dest={{ source_dir }}/ffmpeg
        accept_hostkey=yes
        depth=1

--- a/tasks/libfdk_aac.yml
+++ b/tasks/libfdk_aac.yml
@@ -1,7 +1,7 @@
 ---
 # AAC audio encoder
 - name: GIT clone | libfdk_aac
-  git: repo=git://git.code.sf.net/p/opencore-amr/fdk-aac
+  git: repo=https://github.com/mstorsjo/fdk-aac.git
        dest={{ source_dir }}/libfdk_aac
        accept_hostkey=yes
        depth=1

--- a/tasks/libfdk_aac.yml
+++ b/tasks/libfdk_aac.yml
@@ -7,6 +7,7 @@
        depth=1
 
 - name: Compile | libfdk_aac
+  become: yes
   shell: "export PATH=/usr/local/bin/:$PATH && {{ item }}"
   args:
     chdir: "{{ source_dir }}/libfdk_aac"

--- a/tasks/libmp3lame.yml
+++ b/tasks/libmp3lame.yml
@@ -12,8 +12,8 @@
   become: yes
   shell: "export PATH=/usr/local/bin/:$PATH && {{ item }}"
   args:
-    chdir: "{{ source_dir }}/lame-3.99.5"
-    creates: "{{ bin_dir }}/lame-3.99.5"
+    chdir: "{{ source_dir }}/lame-3.100/"
+    creates: "{{ bin_dir }}/lame-3.100/"
   with_items:
     - ./configure --prefix={{ build_dir }} --bindir={{ bin_dir }} --disable-shared --enable-nasm
     - make

--- a/tasks/libmp3lame.yml
+++ b/tasks/libmp3lame.yml
@@ -5,7 +5,7 @@
 - name: libmp3lame | Unarchive
   unarchive:
     remote_src: yes
-    src: http://downloads.sourceforge.net/project/lame/lame/3.99/lame-3.99.5.tar.gz
+    src: https://downloads.sourceforge.net/project/lame/lame/3.100/lame-3.100.tar.gz
     dest: "{{ source_dir }}"
 
 - name: Compile | libmp3lame

--- a/tasks/libmp3lame.yml
+++ b/tasks/libmp3lame.yml
@@ -9,6 +9,7 @@
     copy: no
 
 - name: Compile | libmp3lame
+  become: yes
   shell: "export PATH=/usr/local/bin/:$PATH && {{ item }}"
   args:
     chdir: "{{ source_dir }}/lame-3.99.5"

--- a/tasks/libmp3lame.yml
+++ b/tasks/libmp3lame.yml
@@ -7,7 +7,6 @@
     remote_src: yes
     src: http://downloads.sourceforge.net/project/lame/lame/3.99/lame-3.99.5.tar.gz
     dest: "{{ source_dir }}"
-    copy: no
 
 - name: Compile | libmp3lame
   become: yes

--- a/tasks/libmp3lame.yml
+++ b/tasks/libmp3lame.yml
@@ -4,6 +4,7 @@
 
 - name: libmp3lame | Unarchive
   unarchive:
+    remote_src: yes
     src: http://downloads.sourceforge.net/project/lame/lame/3.99/lame-3.99.5.tar.gz
     dest: "{{ source_dir }}"
     copy: no

--- a/tasks/libogg.yml
+++ b/tasks/libogg.yml
@@ -7,6 +7,7 @@
     copy: no
 
 - name: Compile | libogg
+  become: yes
   shell: "export PATH=/usr/local/bin/:$PATH && {{ item }}"
   args:
     chdir: "{{ source_dir }}/libogg-1.3.2"

--- a/tasks/libopus.yml
+++ b/tasks/libopus.yml
@@ -8,6 +8,7 @@
       #  accept_hostkey=yes
 
 - name: Compile | libopus
+  become: yes
   shell: "export PATH=/usr/local/bin/:$PATH && {{ item }}"
   args:
     chdir: "{{ source_dir }}/libopus"

--- a/tasks/libvorbis.yml
+++ b/tasks/libvorbis.yml
@@ -7,6 +7,7 @@
     copy: no
 
 - name: Compile | libvorbis
+  become: yes
   shell: "export PATH=/usr/local/bin/:$PATH && {{ item }}"
   args:
     chdir: "{{ source_dir }}/libvorbis-1.3.4"

--- a/tasks/libvpx.yml
+++ b/tasks/libvpx.yml
@@ -7,6 +7,7 @@
        depth=1
 
 - name: Compile | libvpx
+  become: yes
   shell: "export PATH=/usr/local/bin/:$PATH && {{ item }}"
   args:
     chdir: "{{ source_dir }}/libvpx"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include: ff-libraries.yml
+- import_tasks: ff-libraries.yml
 
 - name: ensure source_dir and build_dir exist
   file:
@@ -13,68 +13,68 @@
   stat: path=/usr/local/bin/yasm
   register: yasm_stat
 - name: include yasm
-  include: yasm.yml
+  import_tasks: yasm.yml
   when: yasm_stat.stat.xusr is not defined or yasm_stat.stat.xusr == False
 
 - name: stat x264
   stat: path=/usr/local/bin/x264
   register: x264_stat
 - name: include x264
-  include: x264.yml
+  import_tasks: x264.yml
   when: x264_stat.stat.xusr is not defined or x264_stat.stat.xusr == False
 
 - name: stat x265
   stat: path={{ build_dir }}/lib/libx265.a
   register: x265_stat
 - name: include x264
-  include: x265.yml
+  import_tasks: x265.yml
   when: x265_stat.stat.exists == False
 
 - name: stat libfdk-aac
   stat: path={{ build_dir }}/lib/libfdk-aac.a
   register: aac_stat
 - name: include libfdk-aac
-  include: libfdk_aac.yml
+  import_tasks: libfdk_aac.yml
   when: aac_stat.stat.exists == False
 
 - name: stat lame
   stat: path=/usr/local/bin/lame
   register: lame_stat
 - name: include lame
-  include: libmp3lame.yml
+  import_tasks: libmp3lame.yml
   when: lame_stat.stat.xusr is not defined or lame_stat.stat.xusr == False
 
 - name: stat libopus
   stat: path={{ build_dir }}/lib/libopus.a
   register: opus_stat
 - name: include libopus
-  include: libopus.yml
+  import_tasks: libopus.yml
   when: opus_stat.stat.exists == False
 
 - name: stat libogg
   stat: path={{ build_dir }}/lib/libogg.a
   register: ogg_stat
 - name: include libogg
-  include: libogg.yml
+  import_tasks: libogg.yml
   when: ogg_stat.stat.exists == False
 
 - name: stat libvorbis
   stat: path={{ build_dir }}/lib/libvorbis.a
   register: vorbis_stat
 - name: include libvorbis
-  include: libvorbis.yml
+  import_tasks: libvorbis.yml
   when: vorbis_stat.stat.exists == False
 
 - name: stat libvpx
   stat: path={{ build_dir }}/lib/libvpx.a
   register: vpx_stat
 - name: include libvpx
-  include: libvpx.yml
+  import_tasks: libvpx.yml
   when: vpx_stat.stat.exists == False
 
 - name: stat ffmpeg
   stat: path=/usr/local/bin/ffmpeg
   register: ffmpeg_stat
 - name: include ffmpeg
-  include: ffmpeg.yml
+  import_tasks: ffmpeg.yml
   when: ffmpeg_stat.stat.xusr is not defined or ffmpeg_stat.stat.xusr == False

--- a/tasks/x264.yml
+++ b/tasks/x264.yml
@@ -7,6 +7,7 @@
        depth=1
 
 - name: Compile | libx264
+  become: yes
   shell: "export PATH=/usr/local/bin/:$PATH && {{ item }}"
   args:
     chdir: "{{ source_dir }}/x264"

--- a/tasks/x265.yml
+++ b/tasks/x265.yml
@@ -4,6 +4,7 @@
       dest={{source_dir}}/x265
 
 - name: Compile | libx265
+  become: yes
   shell: "export PATH=/usr/local/bin/:$PATH && {{ item }}"
   args:
     chdir: "{{ source_dir }}/x265/build/linux"

--- a/tasks/yasm.yml
+++ b/tasks/yasm.yml
@@ -7,6 +7,7 @@
        depth=1
 
 - name: Compile | yasm
+  become: yes
   shell: "export PATH=/usr/local/bin/:$PATH && {{ item }}"
   args:
     chdir: "{{ source_dir }}/yasm"

--- a/templates/nasm.repo
+++ b/templates/nasm.repo
@@ -1,0 +1,17 @@
+[nasm]
+name=The Netwide Assembler
+baseurl=http://www.nasm.us/pub/nasm/stable/linux/
+enabled=1
+gpgcheck=0
+
+[nasm-testing]
+name=The Netwide Assembler (release candidate builds)
+baseurl=http://www.nasm.us/pub/nasm/testing/linux/
+enabled=0
+gpgcheck=0
+
+[nasm-snapshot]
+name=The Netwide Assembler (daily snapshot builds)
+baseurl=http://www.nasm.us/pub/nasm/snapshots/latest/linux/
+enabled=0
+gpgcheck=0


### PR DESCRIPTION
This pull request updates the out dated dependencies that were required for building ffmpeg (ex. nasm). Some of the links of sources were not working which I fixed. Also there were some modules which are deprecated in newer versions of Ansible which I fixed.